### PR TITLE
Add username to mariadb to not regenerate password

### DIFF
--- a/seafile/values.yaml
+++ b/seafile/values.yaml
@@ -6,8 +6,9 @@ clusterDomain: cluster.local
 
 # see Bitnami MariaDB Chart Values
 # https://artifacthub.io/packages/helm/bitnami/mariadb
-# mariadb:
-  # auth:
+mariadb:
+  auth:
+    username: seafile
   #   rootPassword: generated-pw-needed-for-chart-upgrade
   # primary:
   #   extraVolumes:


### PR DESCRIPTION
This is needed to prevent always regenerated password on each helm upgrade.
Resolves https://github.com/300481/seafile-server/issues/4