### PR TITLE
support nodeSelector + keep PVCs

### DIFF
--- a/seafile/templates/statefulset.yaml
+++ b/seafile/templates/statefulset.yaml
@@ -24,6 +24,10 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.seafile.persistence.existingClaim }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       containers:
       - name: seafile
         image: {{ .Values.seafile.image }}

--- a/seafile/templates/statefulset.yaml
+++ b/seafile/templates/statefulset.yaml
@@ -55,6 +55,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: seafile-data
+      annotations:
+        helm.sh/resource-policy: keep
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.seafile.persistence.storageClassName }}

--- a/seafile/values.yaml
+++ b/seafile/values.yaml
@@ -36,3 +36,4 @@ ingress:
 # tls:
 #   host: "seafile.example.com"
 #   secretName: seafile-tls
+# nodeSelector: {}


### PR DESCRIPTION
This will optionally allow specifying `nodeSelector` so operators have a bit more control on where the pod lands.

Additionally, annotate the PVC template with a `helm.sh/resource-policy: keep` so that you don't accidentally nuke the PV/PVCs when uninstalling the chart.